### PR TITLE
fix: Force light mode and fix dark theme styling issues

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,65 +1,60 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-  --card: #ffffff;
-  --card-foreground: #171717;
-  --primary: #16a34a;
-  --primary-foreground: #ffffff;
-  --secondary: #f3f4f6;
-  --secondary-foreground: #171717;
-  --muted: #f3f4f6;
-  --muted-foreground: #6b7280;
-  --accent: #f3f4f6;
-  --accent-foreground: #171717;
-  --destructive: #dc2626;
-  --destructive-foreground: #ffffff;
-  --border: #e5e7eb;
-  --input: #e5e7eb;
-  --ring: #16a34a;
+:root,
+.light {
+    --background: #ffffff;
+    --foreground: #171717;
+    --card: #ffffff;
+    --card-foreground: #171717;
+    --primary: #16a34a;
+    --primary-foreground: #ffffff;
+    --secondary: #f3f4f6;
+    --secondary-foreground: #171717;
+    --muted: #f3f4f6;
+    --muted-foreground: #6b7280;
+    --accent: #f3f4f6;
+    --accent-foreground: #171717;
+    --destructive: #dc2626;
+    --destructive-foreground: #ffffff;
+    --border: #e5e7eb;
+    --input: #e5e7eb;
+    --ring: #16a34a;
+    color-scheme: light;
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-destructive-foreground: var(--destructive-foreground);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+    --color-background: var(--background);
+    --color-foreground: var(--foreground);
+    --color-card: var(--card);
+    --color-card-foreground: var(--card-foreground);
+    --color-primary: var(--primary);
+    --color-primary-foreground: var(--primary-foreground);
+    --color-secondary: var(--secondary);
+    --color-secondary-foreground: var(--secondary-foreground);
+    --color-muted: var(--muted);
+    --color-muted-foreground: var(--muted-foreground);
+    --color-accent: var(--accent);
+    --color-accent-foreground: var(--accent-foreground);
+    --color-destructive: var(--destructive);
+    --color-destructive-foreground: var(--destructive-foreground);
+    --color-border: var(--border);
+    --color-input: var(--input);
+    --color-ring: var(--ring);
+    --font-sans: var(--font-geist-sans);
+    --font-mono: var(--font-geist-mono);
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+    background: #ffffff;
+    color: #171717;
+    font-family: Arial, Helvetica, sans-serif;
 }
 
 /* ReactFlow background override */
 .react-flow {
-  background: white !important;
+    background: white !important;
 }
 
 .react-flow__background {
-  background: white !important;
+    background: white !important;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "GPTree",
   description: "Learn anything, one branch at a time.",
-}
+};
 
 export default function RootLayout({
   children,
@@ -27,7 +27,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className="light">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/components/Generic/MarkdownRenderer.tsx
+++ b/components/Generic/MarkdownRenderer.tsx
@@ -8,7 +8,7 @@ import rehypeRaw from "rehype-raw";
 import rehypeHighlight from "rehype-highlight";
 
 import "katex/dist/katex.min.css";
-import "highlight.js/styles/github-dark.css";
+import "highlight.js/styles/github.css";
 
 import { sanitizeMarkdown } from "@/helpers/markdown";
 
@@ -18,7 +18,7 @@ interface MarkdownRendererProps {
 
 const MarkdownRenderer = ({ content }: MarkdownRendererProps) => {
   return (
-    <div className="prose prose-lg max-w-none dark:prose-invert">
+    <div className="prose prose-lg max-w-none">
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[rehypeKatex, rehypeRaw, rehypeHighlight]}
@@ -84,7 +84,10 @@ const MarkdownRenderer = ({ content }: MarkdownRendererProps) => {
           },
           ol({ children, ...props }: any) {
             return (
-              <ol className="list-decimal list-inside mb-4 space-y-2" {...props}>
+              <ol
+                className="list-decimal list-inside mb-4 space-y-2"
+                {...props}
+              >
                 {children}
               </ol>
             );
@@ -99,7 +102,10 @@ const MarkdownRenderer = ({ content }: MarkdownRendererProps) => {
           // Blockquotes
           blockquote({ children, ...props }: any) {
             return (
-              <blockquote className="border-l-4 border-gray-300 pl-4 py-2 my-4 italic bg-gray-50 dark:bg-gray-800" {...props}>
+              <blockquote
+                className="border-l-4 border-gray-300 pl-4 py-2 my-4 italic bg-gray-50"
+                {...props}
+              >
                 {children}
               </blockquote>
             );
@@ -108,7 +114,10 @@ const MarkdownRenderer = ({ content }: MarkdownRendererProps) => {
           table({ children, ...props }: any) {
             return (
               <div className="overflow-x-auto my-4">
-                <table className="min-w-full divide-y divide-gray-300 border border-gray-300" {...props}>
+                <table
+                  className="min-w-full divide-y divide-gray-300 border border-gray-300"
+                  {...props}
+                >
                   {children}
                 </table>
               </div>
@@ -116,7 +125,7 @@ const MarkdownRenderer = ({ content }: MarkdownRendererProps) => {
           },
           thead({ children, ...props }: any) {
             return (
-              <thead className="bg-gray-100 dark:bg-gray-700" {...props}>
+              <thead className="bg-gray-100" {...props}>
                 {children}
               </thead>
             );
@@ -174,13 +183,16 @@ const MarkdownRenderer = ({ content }: MarkdownRendererProps) => {
             const match = /language-(\w+)/.exec(className || "");
             const inline = !match;
             return !inline && match ? (
-              <pre className="rounded-lg bg-gray-900 text-gray-100 p-4 overflow-x-auto my-4">
+              <pre className="rounded-lg bg-gray-100 text-gray-900 p-4 overflow-x-auto my-4 border border-gray-300">
                 <code className={className} {...props}>
                   {children}
                 </code>
               </pre>
             ) : (
-              <code className="bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded text-sm font-mono" {...props}>
+              <code
+                className="bg-gray-100 px-1.5 py-0.5 rounded text-sm font-mono text-gray-900"
+                {...props}
+              >
                 {children}
               </code>
             );


### PR DESCRIPTION
This is a very rudimentary fix that allowed me to use and test the app without the greyed out text issue. I just removed the dark mode features that were forcing text to be grey (while the background was hardcoded white) This also covers math/code blocks. 

There is probably a much better way to fix this, I just figured I would drop what I had in case any parts of it are useful.

- Force light mode by adding className='light' to html element
- Remove dark mode media query conflicts
- Fix MarkdownRenderer to use light theme for code highlighting
- Change code blocks from dark (bg-gray-900) to light (bg-gray-100)
- Remove all dark: prefixed classes for consistent light mode display